### PR TITLE
Fix issue with tiling images from urls with a query string

### DIFF
--- a/init.js
+++ b/init.js
@@ -12,6 +12,6 @@ chrome.contextMenus.create( {
 
 function clicked( info ) {
   chrome.tabs.create( {
-    url: chrome.extension.getURL( 'view.html?url=' + info.srcUrl )
+    url: chrome.extension.getURL( 'view.html?url=' + encodeURIComponent( info.srcUrl ) )
   } );
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Tile View",
   "description": "An easy way to preview images to see if they tile seamlessly as a repeating background texture or wallpaper.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "Ildar Sagdejev",
   "icons": {
     "16": "gfx/icon-16.png",


### PR DESCRIPTION
Added encodeURIComponent to properly encode img src before passing to view.html